### PR TITLE
[WIP]Fix SD Card initialization

### DIFF
--- a/ipl/sdmmc.c
+++ b/ipl/sdmmc.c
@@ -520,7 +520,7 @@ static int _sd_storage_get_op_cond(sdmmc_storage_t *storage, int is_version_1, i
 				storage->has_sector_access = 1;
 			// TODO: Some SD Card incorrectly report low voltage support
 			// Disable it for now
-			if (cond & 0x1000000 && supports_low_voltage && 0)
+			if (cond & 0x1000000 && supports_low_voltage)
 			{
 				//The low voltage regulator configuration is valid for SDMMC1 only.
 				if (storage->sdmmc->id == SDMMC_1 && 
@@ -794,7 +794,8 @@ int sdmmc_storage_init_sd(sdmmc_storage_t *storage, sdmmc_t *sdmmc, u32 id, u32 
 	memcpy(storage->scr, buf, 8);
 	DPRINTF("[sd] got scr\n");
 
-	if (bus_width == SDMMC_BUS_WIDTH_4 && storage->scr[1] & 4)
+	// Check if card supports a wider bus and if it's not SD Version 1.0
+	if (bus_width == SDMMC_BUS_WIDTH_4 && storage->scr[1] & 4 && (storage->scr[0] & 0xF))
 	{
 		if (!_sd_storage_execute_app_cmd_type1(storage, &tmp, SD_APP_SET_BUS_WIDTH, SD_BUS_WIDTH_4, 0, R1_STATE_TRAN))
 		{

--- a/ipl/sdmmc_driver.c
+++ b/ipl/sdmmc_driver.c
@@ -54,24 +54,30 @@ int sdmmc_get_voltage(sdmmc_t *sdmmc)
 
 static int _sdmmc_set_voltage(sdmmc_t *sdmmc, u32 power)
 {
+	u8 pwr = 0;
+
 	switch (power)
 	{
 	case SDMMC_POWER_OFF:
 		sdmmc->regs->pwrcon &= ~TEGRA_MMC_PWRCTL_SD_BUS_POWER;
 		break;
 	case SDMMC_POWER_1_8:
-		sdmmc->regs->pwrcon =
-			(sdmmc->regs->pwrcon & TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_MASK) |
-			TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_V1_8;
+		sdmmc->regs->pwrcon = TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_V1_8;
+		pwr = TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_V1_8;
 		break;
 	case SDMMC_POWER_3_3:
 		sdmmc->regs->pwrcon = TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_V3_3;
+		pwr = TEGRA_MMC_PWRCTL_SD_BUS_VOLTAGE_V3_3;
 		break;
 	default:
 		return 0;
 	}
 
-	sdmmc->regs->pwrcon |= TEGRA_MMC_PWRCTL_SD_BUS_POWER;
+	if (power != SDMMC_POWER_OFF)
+	{
+		pwr |= TEGRA_MMC_PWRCTL_SD_BUS_POWER;
+		sdmmc->regs->pwrcon = pwr;
+	}	
 
 	return 1;
 }


### PR DESCRIPTION
Some sd cards have problem handling the current switch to 1.8v.

Changes:
- Fix switch to low voltage
- Fix the switch to high speed mode for high voltages also.
- Correct the IF COND reply. 0xAA is the important part.
- Add check for bus width switch

TODO:
- [ ] Send correctly host low voltage support to sd card
- [ ] Fix Response Type 2 for CSD and CID
- [ ] Add support for at least 50MHz bus speed and try also for safe 100MHz. Skip 208MHz for now