### PR TITLE
[SDMMC] Add features and bugfixes

### DIFF
--- a/ipl/main.c
+++ b/ipl/main.c
@@ -301,8 +301,36 @@ void print_fuseinfo()
 	gfx_printf(&gfx_con, "%k(Unlocked) fuse cache:\n\n%k", 0xFFFF9955, 0xFFFFFFFF);
 	gfx_hexdump(&gfx_con, 0x7000F900, (u8 *)0x7000F900, 0x2FC);
 
-	sleep(100000);
-	btn_wait();
+	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
+
+	sleep(1000000);
+
+	u32 btn = btn_wait();
+	if (btn & BTN_POWER)
+	{
+		if (!sd_mount())
+		{
+			gfx_printf(&gfx_con, "%kFailed to mount SD card (make sure that it is inserted).%k\n",
+				0xFF0000FF, 0xFFFFFFFF);
+		}
+		else
+		{
+			FIL fuseFp;
+			char fuseFilename[9];
+			memcpy(fuseFilename, "fuse.bin", 8);
+			fuseFilename[8] = 0;
+			if (f_open(&fuseFp, fuseFilename, FA_CREATE_ALWAYS | FA_WRITE) == FR_OK)
+			{
+				f_write(&fuseFp, (u8 *)0x7000F900, 0x2FC, NULL);
+				f_close(&fuseFp);
+				gfx_puts(&gfx_con, "\nDone!\n");
+			}
+			else
+				gfx_printf(&gfx_con, "%k\nError creating fuse.bin file.%k\n", 0xFF0000FF, 0xFFFFFFFF);
+		}
+		sleep(2000000);
+		btn_wait();
+	}
 }
 
 void print_kfuseinfo()
@@ -317,8 +345,36 @@ void print_kfuseinfo()
 	else
 		gfx_hexdump(&gfx_con, 0, (u8 *)buf, KFUSE_NUM_WORDS * 4);
 
-	sleep(100000);
-	btn_wait();
+	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
+
+	sleep(1000000);
+
+	u32 btn = btn_wait();
+	if (btn & BTN_POWER)
+	{
+		if (!sd_mount())
+		{
+			gfx_printf(&gfx_con, "%kFailed to mount SD card (make sure that it is inserted).%k\n",
+				0xFF0000FF, 0xFFFFFFFF);
+		}
+		else
+		{
+			FIL kfuseFp;
+			char kfuseFilename[10];
+			memcpy(kfuseFilename, "kfuse.bin", 9);
+			kfuseFilename[9] = 0;
+			if (f_open(&kfuseFp, kfuseFilename, FA_CREATE_ALWAYS | FA_WRITE) == FR_OK)
+			{
+				f_write(&kfuseFp, (u8 *)buf, KFUSE_NUM_WORDS * 4, NULL);
+				f_close(&kfuseFp);
+				gfx_puts(&gfx_con, "\nDone!\n");
+			}
+			else
+				gfx_printf(&gfx_con, "%k\nError creating kfuse.bin file.%k\n", 0xFF0000FF, 0xFFFFFFFF);
+		}
+		sleep(2000000);
+		btn_wait();
+	}
 }
 
 void print_mmc_info()

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -46,6 +46,7 @@
 #include "se_t210.h"
 #include "hos.h"
 #include "pkg1.h"
+#include "mmc.h"
 
 //TODO: ugly.
 sdmmc_t sd_sdmmc;

--- a/ipl/mmc.h
+++ b/ipl/mmc.h
@@ -289,6 +289,7 @@ c : clear by read
 #define EXT_CSD_CACHE_SIZE		249	/* RO, 4 bytes */
 #define EXT_CSD_PWR_CL_DDR_200_360	253	/* RO */
 #define EXT_CSD_FIRMWARE_VERSION	254	/* RO, 8 bytes */
+#define EXT_CSD_DEVICE_VERSION		262	/* RO, 2 bytes */
 #define EXT_CSD_PRE_EOL_INFO		267	/* RO */
 #define EXT_CSD_DEVICE_LIFE_TIME_EST_TYP_A	268	/* RO */
 #define EXT_CSD_DEVICE_LIFE_TIME_EST_TYP_B	269	/* RO */

--- a/ipl/sd.h
+++ b/ipl/sd.h
@@ -35,10 +35,11 @@
 #define SD_APP_SEND_SCR          51   /* adtc                    R1  */
 
 /* OCR bit definitions */
-#define SD_OCR_S18R		(1 << 24)    /* 1.8V switching request */
-#define SD_ROCR_S18A		SD_OCR_S18R  /* 1.8V switching accepted by card */
-#define SD_OCR_XPC		(1 << 28)    /* SDXC power control */
-#define SD_OCR_CCS		(1 << 30)    /* Card Capacity Status */
+#define SD_OCR_S18R         (1 << 24)    /* 1.8V switching request */
+#define SD_ROCR_S18A        SD_OCR_S18R  /* 1.8V switching accepted by card */
+#define SD_OCR_XPC          (1 << 28)    /* SDXC power control */
+#define SD_OCR_CCS          (1 << 30)    /* Card Capacity Status */
+#define SD_OCR_VDD_32_33    (1 << 20)	 /* VDD voltage 3.2 ~ 3.3 */
 
 /*
 * SD_SWITCH argument format:
@@ -64,16 +65,27 @@
 /*
 * SCR field definitions
 */
-
 #define SCR_SPEC_VER_0		0	/* Implements system specification 1.0 - 1.01 */
 #define SCR_SPEC_VER_1		1	/* Implements system specification 1.10 */
 #define SCR_SPEC_VER_2		2	/* Implements system specification 2.00-3.0X */
+#define SD_SCR_BUS_WIDTH_1	(1<<0)
+#define SD_SCR_BUS_WIDTH_4	(1<<2)
 
 /*
 * SD bus widths
 */
 #define SD_BUS_WIDTH_1		0
 #define SD_BUS_WIDTH_4		2
+
+/*
+* SD bus speeds
+*/
+#define UHS_SDR12_BUS_SPEED		0
+#define HIGH_SPEED_BUS_SPEED	1
+#define UHS_SDR25_BUS_SPEED		1
+#define UHS_SDR50_BUS_SPEED		2
+#define UHS_SDR104_BUS_SPEED	3
+#define UHS_DDR50_BUS_SPEED		4
 
 /*
 * SD_SWITCH mode

--- a/ipl/sdmmc.h
+++ b/ipl/sdmmc.h
@@ -20,6 +20,64 @@
 #include "types.h"
 #include "sdmmc_driver.h"
 
+typedef struct _mmc_cid
+{
+	u32 manfid;
+	u8  prod_name[8];
+	u8  card_bga;
+	u8  prv;
+	u32 serial;
+	u16 oemid;
+	u16	year;
+	u8  hwrev;
+	u8  fwrev;
+	u8  month;
+} mmc_cid_t;
+
+typedef struct _mmc_csd
+{
+	u8		structure;
+	u8		mmca_vsn;
+	u16		cmdclass;
+	u32		c_size;
+	u32		r2w_factor;
+	u32		max_dtr;
+	u32		erase_size;		/* In sectors */
+	u32		read_blkbits;
+	u32		write_blkbits;
+	u32		capacity;
+} mmc_csd_t;
+
+typedef struct _mmc_ext_csd
+{
+	u8  rev;
+	u32 sectors;
+	int bkops;        /* background support bit */
+	int bkops_en;     /* manual bkops enable bit */
+	u8  ext_struct;   /* 194 */
+	u8  card_type;    /* 196 */
+	u8  bkops_status; /* 246 */
+	u16 dev_version;
+	u8  boot_mult;
+	u8  rpmb_mult;
+} mmc_ext_csd_t;
+
+typedef struct _sd_scr
+{
+	u8 sda_vsn;
+	u8 sda_spec3;
+	u8 bus_widths;
+	u8 cmds;
+} sd_scr_t;
+
+typedef struct _sd_ssr {
+	u8 bus_width;
+	u8 speed_class;
+	u8 uhs_grade;
+	u8 video_class;
+	u8 app_class;
+} sd_ssr_t;
+
 /*! SDMMC storage context. */
 typedef struct _sdmmc_storage_t
 {
@@ -29,9 +87,15 @@ typedef struct _sdmmc_storage_t
 	u32 sec_cnt;
 	int is_low_voltage;
 	u32 partition;
-	u8 cid[0x10];
-	u8 csd[0x10];
-	u8 scr[8];
+	u8  raw_cid[0x10];
+	u8  raw_csd[0x10];
+	u8  raw_scr[8];
+	u8  raw_ssr[0x40];
+	mmc_cid_t     cid;
+	mmc_csd_t     csd;
+	mmc_ext_csd_t ext_csd;
+	sd_scr_t      scr;
+	sd_ssr_t      ssr;
 } sdmmc_storage_t;
 
 int sdmmc_storage_end(sdmmc_storage_t *storage);

--- a/ipl/sdmmc_driver.c
+++ b/ipl/sdmmc_driver.c
@@ -304,10 +304,30 @@ static int _sdmmc_cache_rsp(sdmmc_t *sdmmc, u32 *rsp, u32 size, u32 type)
 	case SDMMC_RSP_TYPE_2:
 		if (size < 0x10)
 			return 0;
-		rsp[0] = sdmmc->regs->rspreg0;
-		rsp[1] = sdmmc->regs->rspreg1;
-		rsp[2] = sdmmc->regs->rspreg2;
-		rsp[3] = sdmmc->regs->rspreg3;
+		// CRC is stripped, so shifting is needed.
+		u32 tempreg;
+		for (int i = 0; i < 4; i++)
+		{
+			switch(i)
+			{
+			case 0:
+				tempreg = sdmmc->regs->rspreg3;
+				break;
+			case 1:
+				tempreg = sdmmc->regs->rspreg2;
+				break;
+			case 2:
+				tempreg = sdmmc->regs->rspreg1;
+				break;
+			case 3:
+				tempreg = sdmmc->regs->rspreg0;
+				break;
+			}
+			rsp[i] = tempreg << 8;
+
+			if (i != 0)
+				rsp[i - 1] |= (tempreg >> 24) & 0xFF;
+		}
 		break;
 	default:
 		return 0;


### PR DESCRIPTION
*MMC/SD: Change many hardcoded values to named ones
*MMC/SD: Fix scr/csd/ssr/etc byte/bitfield ordering

Now that the cid/csd/ssr/etc bytes/bitfields are correct:
*MMC/SD: Add cid/csd parsing and use new cid/csd variables
*MMC: Add ext csd parsing and using these variables instead of arrays
*SD: Add scr parsing and using these variables instead of hardcoded ones
*SD: Add ssr (sd status) reading/parsing

*MMC: Fix BKOPS support but disabled
*SD: Add partial sd v1 support
*SD: Fix we support low voltage OCR bit

*Info: Add eMMC and SD info printing
*Tools: Add fuse/kfuse dumping to SD

*Make button check delay 1s to avoid button repressing from "button ip" state
*Dumping: Fix part logic and honor user actions on ignoring errors
*Add time taken to dump emmc

And some other bugfixes