### PR TITLE
Cosmetics, captions in menu and other fixes

### DIFF
--- a/ipl/btn.c
+++ b/ipl/btn.c
@@ -34,9 +34,24 @@ u32 btn_read()
 u32 btn_wait()
 {
 	u32 res = 0, btn = btn_read();
+	int pwr = 0;
+
+	// Power button down, raise a filter.
+	if (btn & BTN_POWER)
+	{
+		pwr = 1;
+		btn &= 0xFFFFFFFE;
+	}
+
 	do
 	{
 		res = btn_read();
+		// Power button up, remove filter.
+		if (!(res & BTN_POWER) && pwr)
+			pwr = 0;
+		// Power button still down.
+		else if (pwr)
+			res &= 0xFFFFFFFE;
 	} while (btn == res);
 	return res;
 }

--- a/ipl/gfx.c
+++ b/ipl/gfx.c
@@ -87,9 +87,9 @@ void gfx_con_init(gfx_con_t *con, gfx_ctxt_t *ctxt)
 	con->gfx_ctxt = ctxt;
 	con->x = 0;
 	con->y = 0;
-	con->fgcol = 0xFFFFFFFF;
+	con->fgcol = 0xFFCCCCCC;
 	con->fillbg = 0;
-	con->bgcol = 0xFF000000;
+	con->bgcol = 0xFF1B1B1B;
 }
 
 void gfx_con_setcol(gfx_con_t *con, u32 fgcol, int fillbg, u32 bgcol)

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -1231,9 +1231,13 @@ void about()
 
 ment_t ment_cinfo[] = {
 	MDEF_BACK(),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("---- SoC Info ----", 0xFFE6B90A),
 	MDEF_HANDLER("Print fuse info", print_fuseinfo),
 	MDEF_HANDLER("Print kfuse info", print_kfuseinfo),
 	MDEF_HANDLER("Print TSEC keys", print_tsec_key),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("-- Storage Info --", 0xFFE6B90A),
 	MDEF_HANDLER("Print eMMC info", print_mmc_info),
 	MDEF_HANDLER("Print SD Card info", print_sdcard_info),
 	MDEF_END()
@@ -1244,6 +1248,7 @@ menu_t menu_cinfo = {
 };
 
 ment_t ment_autorcm[] = {
+	MDEF_CAPTION("WARNING: This corrupts your BOOT0 partition!", 0xFF00FFE6),
 	MDEF_BACK(),
 	MDEF_BACK(),
 	MDEF_BACK(),
@@ -1263,11 +1268,19 @@ menu_t menu_autorcm = {
 
 ment_t ment_tools[] = {
 	MDEF_BACK(),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("------ Full --------", 0xFFE6B90A),
 	MDEF_HANDLER("Dump RAW eMMC", dump_emmc_rawnand),
+	MDEF_HANDLER("Dump eMMC BOOT", dump_emmc_boot),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("-- GP Partitions --", 0xFFE6B90A),
 	MDEF_HANDLER("Dump eMMC SYS", dump_emmc_system),
 	MDEF_HANDLER("Dump eMMC USER", dump_emmc_user),
-	MDEF_HANDLER("Dump eMMC BOOT", dump_emmc_boot),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("------ Misc -------", 0xFFE6B90A),
 	MDEF_HANDLER("Dump package1", dump_package1),
+	MDEF_CHGLINE(),
+	MDEF_CAPTION("---- Dangerous ----", 0xFF0000FF),
 	MDEF_MENU("AutoRCM", &menu_autorcm),
 	MDEF_END()
 };
@@ -1279,11 +1292,14 @@ menu_t menu_tools = {
 
 ment_t ment_top[] = {
 	MDEF_HANDLER("Launch firmware", launch_firmware),
+	MDEF_CAPTION("---------------", 0xFF444444),
 	MDEF_MENU("Tools", &menu_tools),
 	MDEF_MENU("Console info", &menu_cinfo),
-	MDEF_HANDLER("Reboot (normal)", reboot_normal),
-	MDEF_HANDLER("Reboot (rcm)", reboot_rcm),
+	MDEF_CAPTION("---------------", 0xFF444444),
+	MDEF_HANDLER("Reboot (Normal)", reboot_normal),
+	MDEF_HANDLER("Reboot (RCM)", reboot_rcm),
 	MDEF_HANDLER("Power off", power_off),
+	MDEF_CAPTION("---------------", 0xFF444444),
 	MDEF_HANDLER("About", about),
 	MDEF_END()
 };

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -53,8 +53,8 @@ gfx_ctxt_t gfx_ctxt;
 gfx_con_t gfx_con;
 
 //TODO: Create more macros (info, header, debug, etc) with different colors and utilize them for consistency.
-#define EPRINTF(text) gfx_printf(&gfx_con, "%k"text"%k\n", 0xFF0000FF, 0xFFFFFFFF)
-#define EPRINTFARGS(text, args...) gfx_printf(&gfx_con, "%k"text"%k\n", 0xFF0000FF, args, 0xFFFFFFFF)
+#define EPRINTF(text) gfx_printf(&gfx_con, "%k"text"%k\n", 0xFF0000FF, 0xFFCCCCCC)
+#define EPRINTFARGS(text, args...) gfx_printf(&gfx_con, "%k"text"%k\n", 0xFF0000FF, args, 0xFFCCCCCC)
 
 //TODO: ugly.
 sdmmc_t sd_sdmmc;
@@ -336,10 +336,10 @@ void config_hw()
 
 void print_fuseinfo()
 {
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
-	gfx_printf(&gfx_con, "%k(Unlocked) fuse cache:\n\n%k", 0xFFFF9955, 0xFFFFFFFF);
+	gfx_printf(&gfx_con, "%k(Unlocked) fuse cache:\n\n%k", 0xFFFF9955, 0xFFCCCCCC);
 	gfx_hexdump(&gfx_con, 0x7000F900, (u8 *)0x7000F900, 0x2FC);
 
 	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
@@ -368,10 +368,10 @@ void print_fuseinfo()
 
 void print_kfuseinfo()
 {
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
-	gfx_printf(&gfx_con, "%kKFuse contents:\n\n%k", 0xFFFF9955, 0xFFFFFFFF);
+	gfx_printf(&gfx_con, "%kKFuse contents:\n\n%k", 0xFFFF9955, 0xFFCCCCCC);
 	u32 buf[KFUSE_NUM_WORDS];
 	if (!kfuse_read(buf))
 		EPRINTF("CRC fail.");
@@ -404,7 +404,7 @@ void print_kfuseinfo()
 
 void print_mmc_info()
 {
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	static const u32 SECTORS_TO_MIB_COEFF  = 11;
@@ -422,7 +422,7 @@ void print_mmc_info()
 		u16 card_type;
 		u32 speed;
 
-		gfx_printf(&gfx_con, "%kCard IDentification:%k\n", 0xFFFFDD00, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kCard IDentification:%k\n", 0xFFFFDD00, 0xFFCCCCCC);
 		switch (storage.csd.mmca_vsn)
 		{
 		case 0: /* MMC v1.0 - v1.2 */
@@ -466,7 +466,7 @@ void print_mmc_info()
 		else
 		{
 			gfx_printf(&gfx_con, "%kExtended Card-Specific Data V1.%d:%k\n",
-				0xFFFFDD00, storage.ext_csd.ext_struct, 0xFFFFFFFF);
+				0xFFFFDD00, storage.ext_csd.ext_struct, 0xFFCCCCCC);
 			card_type = storage.ext_csd.card_type;
 			u8 card_type_support[96];
 			u8 pos_type = 0;
@@ -515,16 +515,16 @@ void print_mmc_info()
 
 			u32 boot_size = storage.ext_csd.boot_mult << 17;
 			u32 rpmb_size = storage.ext_csd.rpmb_mult << 17;
-			gfx_printf(&gfx_con, "%keMMC Partitions:%k\n", 0xFFFFDD00, 0xFFFFFFFF);
-			gfx_printf(&gfx_con, " 1: %kBOOT0      %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFFFFFFF,
+			gfx_printf(&gfx_con, "%keMMC Partitions:%k\n", 0xFFFFDD00, 0xFFCCCCCC);
+			gfx_printf(&gfx_con, " 1: %kBOOT0      %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFCCCCCC,
 				boot_size / 1024, boot_size / 1024 / 512);
-			gfx_printf(&gfx_con, " 2: %kBOOT1      %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFFFFFFF,
+			gfx_printf(&gfx_con, " 2: %kBOOT1      %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFCCCCCC,
 				boot_size / 1024, boot_size / 1024 / 512);
-			gfx_printf(&gfx_con, " 3: %kRPMB       %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFFFFFFF,
+			gfx_printf(&gfx_con, " 3: %kRPMB       %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFCCCCCC,
 				rpmb_size / 1024, rpmb_size / 1024 / 512);
-			gfx_printf(&gfx_con, " 0: %kGPP (USER) %kSize: %05d MiB (LBA Sectors: 0x%07X)\n\n", 0xFF00FF96, 0xFFFFFFFF,
+			gfx_printf(&gfx_con, " 0: %kGPP (USER) %kSize: %05d MiB (LBA Sectors: 0x%07X)\n\n", 0xFF00FF96, 0xFFCCCCCC,
 				storage.sec_cnt >> SECTORS_TO_MIB_COEFF, storage.sec_cnt);
-			gfx_printf(&gfx_con, "%kGPP (eMMC USER) partition table:%k\n", 0xFFFFDD00, 0xFFFFFFFF);
+			gfx_printf(&gfx_con, "%kGPP (eMMC USER) partition table:%k\n", 0xFFFFDD00, 0xFFCCCCCC);
 
 			sdmmc_storage_set_mmc_partition(&storage, 0);
 			LIST_INIT(gpt);
@@ -532,12 +532,13 @@ void print_mmc_info()
 			int gpp_idx = 0;
 			LIST_FOREACH_ENTRY(emmc_part_t, part, &gpt, link)
 			{
-				gfx_printf(&gfx_con, " %02d: %k%s%k\n     Size: % 5d MiB (LBA Sectors 0x%07X, LBA Range: %08X-%08X)%k\n",
-					gpp_idx++, 0xFF14FDAE, part->name, 0xFFFFFFFF, (part->lba_end - part->lba_start + 1) >> SECTORS_TO_MIB_COEFF,
-					part->lba_end - part->lba_start + 1, part->lba_start, part->lba_end, 0xFFFFFFFF);
+				gfx_printf(&gfx_con, " %02d: %k%s%k\n     Size: % 5d MiB (LBA Sectors 0x%07X, LBA Range: %08X-%08X)\n",
+					gpp_idx++, 0xFF14FDAE, part->name, 0xFFCCCCCC, (part->lba_end - part->lba_start + 1) >> SECTORS_TO_MIB_COEFF,
+					part->lba_end - part->lba_start + 1, part->lba_start, part->lba_end);
 			}
 		}
 	}
+
 out:
 	sdmmc_storage_end(&storage);
 	sleep(1000000);
@@ -547,7 +548,7 @@ out:
 
 void print_sdcard_info()
 {
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	static const u32 SECTORS_TO_MIB_COEFF  = 11;
@@ -556,7 +557,7 @@ void print_sdcard_info()
 	{
 		u32 capacity;
 
-		gfx_printf(&gfx_con, "%kCard IDentification:%k\n", 0xFFFFDD00, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kCard IDentification:%k\n", 0xFFFFDD00, 0xFFCCCCCC);
 		gfx_printf(&gfx_con,
 			" Vendor ID:  %02x\n\
 			 OEM ID:     %c%c\n\
@@ -571,7 +572,7 @@ void print_sdcard_info()
 			sd_storage.cid.hwrev, sd_storage.cid.fwrev, sd_storage.cid.serial,
 			sd_storage.cid.month, sd_storage.cid.year);
 
-		gfx_printf(&gfx_con, "%kCard-Specific Data V%d.0:%k\n", 0xFFFFDD00, sd_storage.csd.structure + 1, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kCard-Specific Data V%d.0:%k\n", 0xFFFFDD00, sd_storage.csd.structure + 1, 0xFFCCCCCC);
 		capacity = sd_storage.csd.capacity >> (20 - sd_storage.csd.read_blkbits);
 		gfx_printf(&gfx_con,
 			" Cmd Classes:    %02X\n\
@@ -589,7 +590,7 @@ void print_sdcard_info()
 		gfx_puts(&gfx_con, "Acquiring FAT volume info...\n\n");
 		f_getfree("", &sd_fs.free_clst, NULL);
 		gfx_printf(&gfx_con, "%kFound %s volume:%k\n Free:    %d MiB\n Cluster: %d B\n",
-				0xFFFFDD00, sd_fs.fs_type == FS_EXFAT ? "exFAT" : "FAT32", 0xFFFFFFFF,
+				0xFFFFDD00, sd_fs.fs_type == FS_EXFAT ? "exFAT" : "FAT32", 0xFFCCCCCC,
 				sd_fs.free_clst * sd_fs.csize >> SECTORS_TO_MIB_COEFF, sd_fs.csize * 512);
 	}
 
@@ -600,7 +601,7 @@ void print_sdcard_info()
 
 void print_tsec_key()
 {
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	sdmmc_storage_t storage;
@@ -625,7 +626,7 @@ void print_tsec_key()
 		u8 key[0x10];
 		int res = tsec_query(key, i, pkg1 + pkg1_id->tsec_off);
 
-		gfx_printf(&gfx_con, "%kTSEC key %d: %k", 0xFFFF9955, i, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kTSEC key %d: %k", 0xFFFF9955, i, 0xFFCCCCCC);
 		if (res >= 0)
 		{
 			for (u32 i = 0; i < 0x10; i++)
@@ -701,7 +702,7 @@ int dump_emmc_part(char *sd_path, sdmmc_storage_t *storage, emmc_part_t *part)
 	{
 		isSmallSdCard = 1;
 
-		gfx_printf(&gfx_con, "%k\nSD card free space is smaller than dump total size.%k\n", 0xFF00BAFF, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%k\nSD card free space is smaller than dump total size.%k\n", 0xFF00BAFF, 0xFFCCCCCC);
 
 		if (!maxSplitParts)
 		{
@@ -713,7 +714,7 @@ int dump_emmc_part(char *sd_path, sdmmc_storage_t *storage, emmc_part_t *part)
 	// Check if we continuing a previous raw eMMC dump in progress.
 	if (f_open(&partialIdxFp, partialIdxFilename, FA_READ) == FR_OK)
 	{
-		gfx_printf(&gfx_con, "%kFound partial dump in progress. Continuing...%k\n\n", 0xFF14FDAE, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kFound partial dump in progress. Continuing...%k\n\n", 0xFF14FDAE, 0xFFCCCCCC);
 
 		partialDumpInProgress = 1;
 		// Force partial dumping, even if the card is larger.
@@ -733,7 +734,7 @@ int dump_emmc_part(char *sd_path, sdmmc_storage_t *storage, emmc_part_t *part)
 		maxSplitParts += currPartIdx;
 	}
 	else if (isSmallSdCard)
-		gfx_printf(&gfx_con, "%kPartial dumping enabled (with %d MiB parts)...%k\n\n", 0xFF00BAFF, multipartSplitSize >> 20, 0xFFFFFFFF);
+		gfx_printf(&gfx_con, "%kPartial dumping enabled (with %d MiB parts)...%k\n\n", 0xFF00BAFF, multipartSplitSize >> 20, 0xFFCCCCCC);
 
 	// Check if filesystem is FAT32 or the free space is smaller and dump in parts
 	if (((sd_fs.fs_type != FS_EXFAT) && totalSectors > (FAT32_FILESIZE_LIMIT / NX_EMMC_BLOCKSIZE)) | isSmallSdCard)
@@ -924,7 +925,7 @@ static void dump_emmc_selected(dumpType_t dumpType)
 {
 	int res = 0;
 	u32 timer = 0;
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	if (!sd_mount())
@@ -959,7 +960,7 @@ static void dump_emmc_selected(dumpType_t dumpType)
 			bootPart.name[5] = 0;
 
 			gfx_printf(&gfx_con, "%k%02d: %s (%08X-%08X)%k\n", 0xFFFFDD00, i,
-				bootPart.name, bootPart.lba_start, bootPart.lba_end, 0xFFFFFFFF);
+				bootPart.name, bootPart.lba_start, bootPart.lba_end, 0xFFCCCCCC);
 
 			sdmmc_storage_set_mmc_partition(&storage, i+1);
 			res = dump_emmc_part(bootPart.name, &storage, &bootPart);
@@ -982,7 +983,7 @@ static void dump_emmc_selected(dumpType_t dumpType)
 					continue;
 
 				gfx_printf(&gfx_con, "%k%02d: %s (%08X-%08X)%k\n", 0xFFFFDD00, i++,
-					part->name, part->lba_start, part->lba_end, 0xFFFFFFFF);
+					part->name, part->lba_start, part->lba_end, 0xFFCCCCCC);
 
 				res = dump_emmc_part(part->name, &storage, part);
 			}
@@ -999,7 +1000,7 @@ static void dump_emmc_selected(dumpType_t dumpType)
 			strcpy(rawPart.name, "rawnand.bin");
 			{
 				gfx_printf(&gfx_con, "%k%02d: %s (%08X-%08X)%k\n", 0xFFFFDD00, i++,
-					rawPart.name, rawPart.lba_start, rawPart.lba_end, 0xFFFFFFFF);
+					rawPart.name, rawPart.lba_start, rawPart.lba_end, 0xFFCCCCCC);
 
 				res = dump_emmc_part(rawPart.name, &storage, &rawPart);
 			}
@@ -1007,7 +1008,7 @@ static void dump_emmc_selected(dumpType_t dumpType)
 	}
 
 	gfx_putc(&gfx_con, '\n');
-	gfx_printf(&gfx_con, "%kTime taken: %d seconds.%k\n", 0xFF00FF96, (get_tmr() - timer) / 1000000, 0xFFFFFFFF);
+	gfx_printf(&gfx_con, "%kTime taken: %d seconds.%k\n", 0xFF00FF96, (get_tmr() - timer) / 1000000, 0xFFCCCCCC);
 	sdmmc_storage_end(&storage);
 	if (res)
 		gfx_puts(&gfx_con, "\nDone. Press any key.\n");
@@ -1028,7 +1029,7 @@ void dump_package1()
 	u8 * warmboot = (u8 *)malloc(0x40000);
 	u8 * secmon = (u8 *)malloc(0x40000);
 
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	if (!sd_mount())
@@ -1065,9 +1066,9 @@ void dump_package1()
 	pkg1_unpack(warmboot, secmon, pkg1_id, pkg1);
 
 	// display info
-	gfx_printf(&gfx_con, "%kSecure monitor addr: %08X\n", 0xFF00FFA8, pkg1_id->secmon_base);
-	gfx_printf(&gfx_con, "%kSecure monitor size: %08X\n", 0xFF00FFA8, hdr->sm_size);
-	gfx_printf(&gfx_con, "%kSecure monitor off: %08X\n", 0xFF00FFA8, hdr->sm_off);
+	gfx_printf(&gfx_con, "%kSecure monitor addr: %k%08X\n", 0xFF46EAC7, 0xFFCCCCCC, pkg1_id->secmon_base);
+	gfx_printf(&gfx_con, "%kSecure monitor size: %k%08X\n", 0xFF46EAC7, 0xFFCCCCCC, hdr->sm_size);
+	gfx_printf(&gfx_con, "%kSecure monitor ofst: %k%08X\n", 0xFF46EAC7, 0xFFCCCCCC, hdr->sm_off);
 
 	// dump package1
 	if (sd_save_to_file(pkg1, 0x40000, "pkg_decr.bin")) {
@@ -1107,7 +1108,7 @@ void launch_firmware()
 	ini_sec_t *cfg_sec = NULL;
 	LIST_INIT(ini_sections);
 
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
 	if (sd_mount())
@@ -1183,7 +1184,7 @@ void toggle_autorcm(){
 	free(tempbuf);
 	sdmmc_storage_end(&storage);
 	
-	gfx_printf(&gfx_con, "%kAutoRCM mode toggled!%k\n", 0xFF00EE2C, 0xFFFFFFFF);
+	gfx_printf(&gfx_con, "%kAutoRCM mode toggled!%k\n", 0xFF00EE2C, 0xFFCCCCCC);
 
 out:;
 	sleep(1000000);
@@ -1218,11 +1219,11 @@ void about()
 	"             (/`    ( (`          ) )  '-;   %k[switchbrew]%k\n"
 	"              `      '-;         (-'%k";
 
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_setpos(&gfx_con, 0, 0);
 
-	gfx_printf(&gfx_con, octopus, 0xFFFFCC00, 0xFFFFFFFF,
-		0xFFFFCC00, 0xFFCCFF00, 0xFFFFCC00, 0xFFFFFFFF);
+	gfx_printf(&gfx_con, octopus, 0xFFFFCC00, 0xFFCCCCCC,
+		0xFFFFCC00, 0xFFCCFF00, 0xFFFFCC00, 0xFFCCCCCC);
 
 	sleep(1000000);
 	btn_wait();
@@ -1310,7 +1311,7 @@ void ipl_main()
 	//display_color_screen(0xAABBCCDD);
 	u32 *fb = display_init_framebuffer();
 	gfx_init_ctxt(&gfx_ctxt, fb, 720, 1280, 768);
-	gfx_clear(&gfx_ctxt, 0xFF000000);
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
 	gfx_con_init(&gfx_con, &gfx_ctxt);
 
 	while (1)

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -344,14 +344,11 @@ void print_fuseinfo()
 
 	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
 
-	sleep(1000000);
-
 	u32 btn = btn_wait();
 	if (btn & BTN_POWER)
 	{
 		if (sd_mount())
 		{
-			FIL fuseFp;
 			char fuseFilename[9];
 			memcpy(fuseFilename, "fuse.bin", 8);
 			fuseFilename[8] = 0;
@@ -361,7 +358,7 @@ void print_fuseinfo()
 			else
 				gfx_puts(&gfx_con, "\nDone!\n");				
 		}
-		sleep(2000000);
+
 		btn_wait();
 	}
 }
@@ -380,14 +377,11 @@ void print_kfuseinfo()
 
 	gfx_puts(&gfx_con, "\nPress POWER to dump them to SD Card.\nPress VOL to go to the menu.\n");
 
-	sleep(1000000);
-
 	u32 btn = btn_wait();
 	if (btn & BTN_POWER)
 	{
 		if (sd_mount())
 		{
-			FIL kfuseFp;
 			char kfuseFilename[10];
 			memcpy(kfuseFilename, "kfuse.bin", 9);
 			kfuseFilename[9] = 0;
@@ -397,7 +391,7 @@ void print_kfuseinfo()
 			else
 				gfx_puts(&gfx_con, "\nDone!\n");
 		}
-		sleep(2000000);
+
 		btn_wait();
 	}
 }
@@ -541,7 +535,6 @@ void print_mmc_info()
 
 out:
 	sdmmc_storage_end(&storage);
-	sleep(1000000);
 
 	btn_wait();
 }
@@ -594,8 +587,6 @@ void print_sdcard_info()
 				sd_fs.free_clst * sd_fs.csize >> SECTORS_TO_MIB_COEFF, sd_fs.csize * 512);
 	}
 
-	sleep(1000000);
-
 	btn_wait();
 }
 
@@ -640,7 +631,6 @@ void print_tsec_key()
 out:;
 	free(pkg1);
 	sdmmc_storage_end(&storage);
-	sleep(1000000);
 	btn_wait();
 }
 
@@ -1014,7 +1004,6 @@ static void dump_emmc_selected(dumpType_t dumpType)
 		gfx_puts(&gfx_con, "\nDone. Press any key.\n");
 
 out:;
-	sleep(1000000);
 	btn_wait();
 }
 
@@ -1099,7 +1088,7 @@ out:;
 	free(pkg1);
 	free(secmon);
 	free(warmboot);
-	sleep(1000000);
+
 	btn_wait();
 }
 
@@ -1187,7 +1176,6 @@ void toggle_autorcm(){
 	gfx_printf(&gfx_con, "%kAutoRCM mode toggled!%k\n", 0xFF00EE2C, 0xFFCCCCCC);
 
 out:;
-	sleep(1000000);
 	btn_wait();
 }
 
@@ -1225,7 +1213,6 @@ void about()
 	gfx_printf(&gfx_con, octopus, 0xFFFFCC00, 0xFFCCCCCC,
 		0xFFFFCC00, 0xFFCCFF00, 0xFFFFCC00, 0xFFCCCCCC);
 
-	sleep(1000000);
 	btn_wait();
 }
 

--- a/ipl/tui.c
+++ b/ipl/tui.c
@@ -42,28 +42,28 @@ void *tui_do_menu(gfx_con_t *con, menu_t *menu)
 {
 	int idx = 0, cnt;
 
-	gfx_clear(con->gfx_ctxt, 0xFF000000);
+	gfx_clear(con->gfx_ctxt, 0xFF1B1B1B);
 
 	while (1)
 	{
-		gfx_con_setcol(con, 0xFFFFFFFF, 1, 0xFF000000);
+		gfx_con_setcol(con, 0xFFCCCCCC, 1, 0xFF1B1B1B);
 		gfx_con_setpos(con, menu->x, menu->y);
 		gfx_printf(con, "[%s]\n\n", menu->caption);
 
+		// Draw the menu
 		for (cnt = 0; menu->ents[cnt].type != MENT_END; cnt++)
 		{
 			if (cnt == idx)
-				gfx_con_setcol(con, 0xFF000000, 1, 0xFFCCCCCC);
+				gfx_con_setcol(con, 0xFF1B1B1B, 1, 0xFFCCCCCC);
 			else
-				gfx_con_setcol(con, 0xFFFFFFFF, 1, 0xFF000000);
+				gfx_con_setcol(con, 0xFFCCCCCC, 1, 0xFF1B1B1B);
 			con->x += 8;
 			gfx_printf(con, "%s", menu->ents[cnt].caption);
 			if(menu->ents[cnt].type == MENT_MENU)
 				gfx_printf(con, "%k...", 0xFFEE9900);
 			gfx_putc(con, '\n');
 		}
-
-		gfx_con_setcol(con, 0xFFFFFFFF, 1, 0xFF000000);
+		gfx_con_setcol(con, 0xFFCCCCCC, 1, 0xFF1B1B1B);
 		gfx_putc(con, '\n');
 
 		u32 btn = btn_wait();
@@ -94,7 +94,7 @@ void *tui_do_menu(gfx_con_t *con, menu_t *menu)
 				return NULL;
 				break;
 			}
-			gfx_clear(con->gfx_ctxt, 0xFF000000);
+			gfx_clear(con->gfx_ctxt, 0xFF1B1B1B);
 		}
 	}
 

--- a/ipl/tui.h
+++ b/ipl/tui.h
@@ -20,16 +20,19 @@
 #include "types.h"
 #include "gfx.h"
 
-#define MENT_END 0
+#define MENT_END     0
 #define MENT_HANDLER 1
-#define MENT_MENU 2
-#define MENT_CHOICE 3
-#define MENT_BACK 4
+#define MENT_MENU    2
+#define MENT_CHOICE  3
+#define MENT_BACK    4
+#define MENT_CAPTION 5
+#define MENT_CHGLINE 6
 
 typedef struct _ment_t
 {
 	u32 type;
 	const char *caption;
+	u32 color;
 	void *data;
 	union
 	{
@@ -47,10 +50,12 @@ typedef struct _menu_t
 } menu_t;
 
 #define MDEF_END() {MENT_END}
-#define MDEF_HANDLER(caption, _handler) { MENT_HANDLER, caption, NULL, { .handler = _handler } }
-#define MDEF_HANDLER_EX(caption, data, _handler) { MENT_HANDLER, caption, data, { .handler = _handler } }
-#define MDEF_MENU(caption, _menu) { MENT_MENU, caption, NULL, { .menu = _menu } }
+#define MDEF_HANDLER(caption, _handler) { MENT_HANDLER, caption, 0, NULL, { .handler = _handler } }
+#define MDEF_HANDLER_EX(caption, data, _handler) { MENT_HANDLER, caption, 0, data, { .handler = _handler } }
+#define MDEF_MENU(caption, _menu) { MENT_MENU, caption, 0, NULL, { .menu = _menu } }
 #define MDEF_BACK() { MENT_BACK, "Back" }
+#define MDEF_CAPTION(caption, color) { MENT_CAPTION, caption, color }
+#define MDEF_CHGLINE() {MENT_CHGLINE}
 
 void tui_pbar(gfx_con_t *con, int x, int y, u32 val);
 void *tui_do_menu(gfx_con_t *con, menu_t *menu);


### PR DESCRIPTION
This PR is in 3 main parts:

**Cosmetics:**
- Background changed to a subtle dark grey (`#1B1B1B`) and main text color to light grey (`#CCCCCC`)
- Menu now supports colored captions and line seperators
- The captions and the separators are skipped in selection to maintain flow and autoscroll to top/bottom still works

The menu now looks like this:
![](https://i.imgur.com/mmncgxO.png) ![](https://i.imgur.com/HxvXmLY.png) ![](https://i.imgur.com/n05C9yJ.png)

The colors are normally a subjective change though and can be removed from the PR.
In my opinion, these subtle color changes modernize the overall look.


**Filtered power button on down state:**
Power button gets filtered if the btn_wait() starts with it in down state. This fixes the double presses in all cases and removes the need for sleep().


**Other:**
Some small fixes in messages, whitespaces, etc.
