### PR TITLE
[PKG1][LP0][Backup] Major feature changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ OBJS = $(addprefix $(BUILD)/, \
 OBJS += $(addprefix $(BUILD)/, diskio.o ff.o ffunicode.o)
 
 ARCH := -march=armv4t -mtune=arm7tdmi -mthumb -mthumb-interwork
-CFLAGS = $(ARCH) -Os -nostdlib -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11# -Wall
+CFLAGS = $(ARCH) -O2 -nostdlib -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-inline -std=gnu11# -Wall
 LDFLAGS = $(ARCH) -nostartfiles -lgcc -Wl,--nmagic,--gc-sections
 
 .PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -4,13 +4,49 @@
 
 Nintendo Switch bootloader, firmware patcher, and more.
 
+
 ## ipl config
 
 The ipl can be configured via 'hekate_ipl.ini' (if it is present on the SD card). Each ini section represents a boot entry, except for the special section 'config' that controls the global configuration.
 
-Possible key/value combinations:
+### Possible key/value combinations:
 
- - warmboot={SD path}
- - secmon={SD path}
- - kernel={SD path}
- - kip1={SD path}
+| Config option      | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| warmboot={SD path} | Replaces the warmboot binary                               |
+| secmon={SD path}   | Replaces the security monitor binary                       |
+| kernel={SD path}   | Replaces the kernel binary                                 |
+| kip1={SD path}     | Replaces/Adds kernel initial process. Multiple can be set. |
+| fullsvcperm=1      | Disables SVC verification                                  |
+| debugmode=1        | Enables Debug mode                                         |
+
+
+
+```
+hekate (C) 2018 naehrwert, st4rk.
+
+Thanks to: derrek, nedwill, plutoo, shuffle2, smea, thexyz, yellows8.
+Greetings to: fincs, hexkyz, SciresM, Shiny Quagsire, WinterMute.
+
+Open source and free packages used:
+ - FatFs R0.13a, Copyright (C) 2017, ChaN
+ - bcl-1.2.0,    Copyright (C) 2003-2006, Marcus Geelnard
+
+                         ___
+                      .-'   `'.
+                     /         \
+                     |         ;
+                     |         |           ___.--,
+            _.._     |0) = (0) |    _.---'`__.-( (_.
+     __.--'`_.. '.__.\    '--. \_.-' ,.--'`     `""`
+    ( ,.--'`   ',__ /./;   ;, '.__.'`    __
+    _`) )  .---.__.' / |   |\   \__..--""  """--.,_
+   `---' .'.''-._.-'`_./  /\ '.  \ _.--''````'''--._`-.__.'
+         | |  .' _.-' |  |  \  \  '.               `----`
+          \ \/ .'     \  \   '. '-._)
+           \/ /        \  \    `=.__`'-.
+           / /\         `) )    / / `"".`\
+     , _.-'.'\ \        / /    ( (     / /
+      `--'`   ) )    .-'.'      '.'.  | (
+             (/`    ( (`          ) )  '-;   [switchbrew]
+```

--- a/ipl/ff.c
+++ b/ipl/ff.c
@@ -26,7 +26,7 @@
 #include "gfx.h"
 extern gfx_ctxt_t gfx_ctxt;
 extern gfx_con_t gfx_con;
-#define EFSPRINTF(text, ...) gfx_printf(&gfx_con, "\n\n\n%k[FatFS] "text"%k\n", 0xFF00FFFF, 0xFFFFFFFF)
+#define EFSPRINTF(text, ...) gfx_printf(&gfx_con, "\n\n\n%k[FatFS] Error: "text"%k\n", 0xFF00FFFF, 0xFFFFFFFF)
 //#define EFSPRINTF(...)
 
 /*--------------------------------------------------------------------------
@@ -3259,7 +3259,7 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		stat = disk_status(fs->pdrv);
 		if (!(stat & STA_NOINIT)) {		/* and the physical drive is kept initialized */
 			if (!FF_FS_READONLY && mode && (stat & STA_PROTECT)) {	/* Check write protection if needed */
-				EFSPRINTF("Error: Write protected!");
+				EFSPRINTF("Write protected!");
 				return FR_WRITE_PROTECTED;
 			}
 			return FR_OK;				/* The filesystem object is valid */
@@ -3273,11 +3273,11 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 	fs->pdrv = LD2PD(vol);				/* Bind the logical drive and a physical drive */
 	stat = disk_initialize(fs->pdrv);	/* Initialize the physical drive */
 	if (stat & STA_NOINIT) { 			/* Check if the initialization succeeded */
-		EFSPRINTF("Error: Medium not ready or hard error!");
+		EFSPRINTF("Medium not ready or hard error!");
 		return FR_NOT_READY;			/* Failed to initialize due to no medium or hard error */
 	}
 	if (!FF_FS_READONLY && mode && (stat & STA_PROTECT)) { /* Check disk write protection if needed */
-		EFSPRINTF("Error: Write protected!");
+		EFSPRINTF("Write protected!");
 		return FR_WRITE_PROTECTED;
 	}
 #if FF_MAX_SS != FF_MIN_SS				/* Get sector size (multiple sector size cfg only) */
@@ -3301,11 +3301,11 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		} while (LD2PT(vol) == 0 && fmt >= 2 && ++i < 4);
 	}
 	if (fmt == 4) {
-		EFSPRINTF("Error: Disk I/O error - Could not load boot record!");
+		EFSPRINTF("Disk I/O error - Could not load boot record!");
 		return FR_DISK_ERR;		/* An error occured in the disk I/O layer */
 	}
 	if (fmt >= 2) {
-		EFSPRINTF("Error: No FAT/FAT32/exFAT filesystem found!");
+		EFSPRINTF("No FAT/FAT32/exFAT filesystem found!");
 		return FR_NO_FILESYSTEM;	/* No FAT volume is found */
 	}
 
@@ -3316,21 +3316,24 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		QWORD maxlba;
 
 		for (i = BPB_ZeroedEx; i < BPB_ZeroedEx + 53 && fs->win[i] == 0; i++) ;	/* Check zero filler */
-		if (i < BPB_ZeroedEx + 53) return FR_NO_FILESYSTEM;
+		if (i < BPB_ZeroedEx + 53) {
+			EFSPRINTF("exFAT - Zero filler check failed!");
+			return FR_NO_FILESYSTEM;
+		}
 
 		if (ld_word(fs->win + BPB_FSVerEx) != 0x100) {
-			EFSPRINTF("Error: exFAT - Version check failed!");
+			EFSPRINTF("exFAT - Version check failed!");
 			return FR_NO_FILESYSTEM;	/* Check exFAT version (must be version 1.0) */
 		}
 
 		if (1 << fs->win[BPB_BytsPerSecEx] != SS(fs)) {	/* (BPB_BytsPerSecEx must be equal to the physical sector size) */
-			EFSPRINTF("Error: exFAT - Bytes per sector does not match physical sector size!");
+			EFSPRINTF("exFAT - Bytes per sector does not match physical sector size!");
 			return FR_NO_FILESYSTEM;
 		}
 
 		maxlba = ld_qword(fs->win + BPB_TotSecEx) + bsect;	/* Last LBA + 1 of the volume */
 		if (maxlba >= 0x100000000) {
-			EFSPRINTF("Error: exFAT - Cannot handle volume LBA with 32-bit LBA!");
+			EFSPRINTF("exFAT - Cannot handle volume LBA with 32-bit LBA!");
 			return FR_NO_FILESYSTEM;	/* (It cannot be handled in 32-bit LBA) */
 		}
 
@@ -3338,19 +3341,19 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 
 		fs->n_fats = fs->win[BPB_NumFATsEx];			/* Number of FATs */
 		if (fs->n_fats != 1) {
-			EFSPRINTF("Error: exFAT - Multiple or no file allocation tables found!");
+			EFSPRINTF("exFAT - Multiple or no file allocation tables found!");
 			return FR_NO_FILESYSTEM;	/* (Supports only 1 FAT) */
 		}
 
 		fs->csize = 1 << fs->win[BPB_SecPerClusEx];		/* Cluster size */
 		if (fs->csize == 0)	{
-			EFSPRINTF("Error: exFAT - Cluster size is not between 1KB - 32KB!");
+			EFSPRINTF("exFAT - Cluster size is not between 1KB - 32KB!");
 			return FR_NO_FILESYSTEM;	/* (Must be 1..32768) */
 		}
 
 		nclst = ld_dword(fs->win + BPB_NumClusEx);		/* Number of clusters */
 		if (nclst > MAX_EXFAT) {
-			EFSPRINTF("Error: exFAT - Total clusters exceed allowed!");
+			EFSPRINTF("exFAT - Total clusters exceed allowed!");
 			return FR_NO_FILESYSTEM;	/* (Too many clusters) */
 		}
 		fs->n_fatent = nclst + 2;
@@ -3360,20 +3363,23 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		fs->database = bsect + ld_dword(fs->win + BPB_DataOfsEx);
 		fs->fatbase = bsect + ld_dword(fs->win + BPB_FatOfsEx);
 		if (maxlba < (QWORD)fs->database + nclst * fs->csize) {
-			EFSPRINTF("Error: exFAT - Volume size is lower than required!");
+			EFSPRINTF("exFAT - Volume size is lower than required!");
 			return FR_NO_FILESYSTEM;	/* (Volume size must not be smaller than the size required) */
 		}
 		fs->dirbase = ld_dword(fs->win + BPB_RootClusEx);
 
 		/* Check if bitmap location is in assumption (at the first cluster) */
 		if (move_window(fs, clst2sect(fs, fs->dirbase)) != FR_OK) {
-			EFSPRINTF("Error: exFAT - Bitmap location not at first cluster!");
+			EFSPRINTF("exFAT - Bitmap location not at first cluster!");
 			return FR_DISK_ERR;
 		}
 		for (i = 0; i < SS(fs); i += SZDIRE) {
 			if (fs->win[i] == 0x81 && ld_dword(fs->win + i + 20) == 2) break;	/* 81 entry with cluster #2? */
 		}
-		if (i == SS(fs)) return FR_NO_FILESYSTEM;
+		if (i == SS(fs)) {
+			EFSPRINTF("exFAT - Bitmap allocation is missing!");
+			return FR_NO_FILESYSTEM;
+		}
 #if !FF_FS_READONLY
 		fs->last_clst = fs->free_clst = 0xFFFFFFFF;		/* Initialize cluster allocation information */
 #endif
@@ -3382,7 +3388,7 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 #endif	/* FF_FS_EXFAT */
 	{
 		if (ld_word(fs->win + BPB_BytsPerSec) != SS(fs)) {
-			EFSPRINTF("Error: FAT - Bytes per sector does not match physical sector size!");
+			EFSPRINTF("FAT - Bytes per sector does not match physical sector size!");
 			return FR_NO_FILESYSTEM;	/* (BPB_BytsPerSec must be equal to the physical sector size) */
 		}
 
@@ -3392,20 +3398,20 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 
 		fs->n_fats = fs->win[BPB_NumFATs];				/* Number of FATs */
 		if (fs->n_fats != 1 && fs->n_fats != 2) {
-			EFSPRINTF("Error: FAT - No or more than 2 file allocation tables found!");
+			EFSPRINTF("FAT - No or more than 2 file allocation tables found!");
 			return FR_NO_FILESYSTEM;	/* (Must be 1 or 2) */
 		}
 		fasize *= fs->n_fats;							/* Number of sectors for FAT area */
 
 		fs->csize = fs->win[BPB_SecPerClus];			/* Cluster size */
 		if (fs->csize == 0 || (fs->csize & (fs->csize - 1))) {
-			EFSPRINTF("Error: FAT - Cluster size is not a power of 2!");
+			EFSPRINTF("FAT - Cluster size is not a power of 2!");
 			return FR_NO_FILESYSTEM;	/* (Must be power of 2) */
 		}
 
 		fs->n_rootdir = ld_word(fs->win + BPB_RootEntCnt);	/* Number of root directory entries */
 		if (fs->n_rootdir % (SS(fs) / SZDIRE)) {
-			EFSPRINTF("Error: FAT - Root directory entries are not sector aligned!");
+			EFSPRINTF("FAT - Root directory entries are not sector aligned!");
 			return FR_NO_FILESYSTEM;	/* (Must be sector aligned) */
 		}
 
@@ -3414,19 +3420,19 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 
 		nrsv = ld_word(fs->win + BPB_RsvdSecCnt);		/* Number of reserved sectors */
 		if (nrsv == 0) {
-			EFSPRINTF("Error: FAT - Zero reserved sectors!");
+			EFSPRINTF("FAT - Zero reserved sectors!");
 			return FR_NO_FILESYSTEM;			/* (Must not be 0) */
 		}
 
 		/* Determine the FAT sub type */
 		sysect = nrsv + fasize + fs->n_rootdir / (SS(fs) / SZDIRE);	/* RSV + FAT + DIR */
 		if (tsect < sysect) {
-			EFSPRINTF("Error: FAT - Invalid volume size!");
+			EFSPRINTF("FAT - Invalid volume size!");
 			return FR_NO_FILESYSTEM;	/* (Invalid volume size) */
 		}
 		nclst = (tsect - sysect) / fs->csize;			/* Number of clusters */
 		if (nclst == 0) {
-			EFSPRINTF("Error: FAT - Invalid volume size!");
+			EFSPRINTF("FAT - Invalid volume size!");
 			return FR_NO_FILESYSTEM;		/* (Invalid volume size) */
 		}
 		fmt = 0;
@@ -3434,7 +3440,7 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		if (nclst <= MAX_FAT16) fmt = FS_FAT16;
 		if (nclst <= MAX_FAT12) fmt = FS_FAT12;
 		if (fmt == 0) {
-			EFSPRINTF("Error: FAT - Not compatible FAT12/16/32 filesystem!");
+			EFSPRINTF("FAT - Not compatible FAT12/16/32 filesystem!");
 			return FR_NO_FILESYSTEM;
 		}
 
@@ -3445,18 +3451,18 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 		fs->database = bsect + sysect;					/* Data start sector */
 		if (fmt == FS_FAT32) {
 			if (ld_word(fs->win + BPB_FSVer32) != 0) {
-				EFSPRINTF("Error: FAT32 - Not a 0.0 revision!");
+				EFSPRINTF("FAT32 - Not a 0.0 revision!");
 				return FR_NO_FILESYSTEM;	/* (Must be FAT32 revision 0.0) */
 			}
 			if (fs->n_rootdir != 0) {
-				EFSPRINTF("Error: FAT32 - Root entry sector is not 0!");
+				EFSPRINTF("FAT32 - Root entry sector is not 0!");
 				return FR_NO_FILESYSTEM;	/* (BPB_RootEntCnt must be 0) */
 			}
 			fs->dirbase = ld_dword(fs->win + BPB_RootClus32);	/* Root directory start cluster */
 			szbfat = fs->n_fatent * 4;					/* (Needed FAT size) */
 		} else {
 			if (fs->n_rootdir == 0)	{
-				EFSPRINTF("Error: FAT - Root entry sector is 0!");
+				EFSPRINTF("FAT - Root entry sector is 0!");
 				return FR_NO_FILESYSTEM;	/* (BPB_RootEntCnt must not be 0) */
 			}
 			fs->dirbase = fs->fatbase + fasize;			/* Root directory start sector */
@@ -3464,7 +3470,7 @@ FRESULT find_volume (	/* FR_OK(0): successful, !=0: any error occurred */
 				fs->n_fatent * 2 : fs->n_fatent * 3 / 2 + (fs->n_fatent & 1);
 		}
 		if (fs->fsize < (szbfat + (SS(fs) - 1)) / SS(fs)) {
-			EFSPRINTF("Error: FAT - FAT size is not the required size!");
+			EFSPRINTF("FAT - FAT size is not the required size!");
 			return FR_NO_FILESYSTEM;	/* (BPB_FATSz must not be less than the size needed) */
 		}
 
@@ -3578,7 +3584,7 @@ FRESULT f_mount (
 	/* Get logical drive number */
 	vol = get_ldnumber(&rp);
 	if (vol < 0) {
-		EFSPRINTF("Error: Invalid drive!");
+		EFSPRINTF("Invalid drive!");
 		return FR_INVALID_DRIVE;
 	}
 	cfs = FatFs[vol];					/* Pointer to fs object */
@@ -3822,11 +3828,11 @@ FRESULT f_read (
 	*br = 0;	/* Clear read byte counter */
 	res = validate(&fp->obj, &fs);				/* Check validity of the file object */
 	if (res != FR_OK || (res = (FRESULT)fp->err) != FR_OK) {
-		EFSPRINTF("Error: File object Validation!");
+		EFSPRINTF("File object Validation!");
 		LEAVE_FF(fs, res);	/* Check validity */
 	}
 	if (!(fp->flag & FA_READ)) {
-		EFSPRINTF("Error: Access denied!");
+		EFSPRINTF("Access denied!");
 		LEAVE_FF(fs, FR_DENIED);	/* Check access mode */
 	}
 	remain = fp->obj.objsize - fp->fptr;
@@ -3850,18 +3856,18 @@ FRESULT f_read (
 					}
 				}
 				if (clst < 2) {
-					EFSPRINTF("Error: Cluster status check or Internal error!");
+					EFSPRINTF("Cluster status check or Internal error!");
 					ABORT(fs, FR_INT_ERR);
 				}
 				if (clst == 0xFFFFFFFF) {
-					EFSPRINTF("Error: Disk error (cluster hard error)!");
+					EFSPRINTF("Disk error (cluster hard error)!");
 					ABORT(fs, FR_DISK_ERR);
 				}
 				fp->clust = clst;				/* Update current cluster */
 			}
 			sect = clst2sect(fs, fp->clust);	/* Get current sector */
 			if (sect == 0) {
-				EFSPRINTF("Error: Get current sector error!");
+				EFSPRINTF("Get current sector error!");
 				ABORT(fs, FR_INT_ERR);
 			}
 			sect += csect;
@@ -3871,7 +3877,7 @@ FRESULT f_read (
 					cc = fs->csize - csect;
 				}
 				if (disk_read(fs->pdrv, rbuff, sect, cc) != RES_OK) {
-					EFSPRINTF("Error: Read - Low level disk I/O!");
+					EFSPRINTF("Read - Low level disk I/O!");
 					ABORT(fs, FR_DISK_ERR);
 				}
 #if !FF_FS_READONLY && FF_FS_MINIMIZE <= 2		/* Replace one of the read sectors with cached data if it contains a dirty sector */
@@ -3893,14 +3899,14 @@ FRESULT f_read (
 #if !FF_FS_READONLY
 				if (fp->flag & FA_DIRTY) {		/* Write-back dirty sector cache */
 					if (disk_write(fs->pdrv, fp->buf, fp->sect, 1) != RES_OK) {
-						EFSPRINTF("Error: Write-back dirty sector cache!");
+						EFSPRINTF("Write-back dirty sector cache!");
 						ABORT(fs, FR_DISK_ERR);
 					}
 					fp->flag &= (BYTE)~FA_DIRTY;
 				}
 #endif
 				if (disk_read(fs->pdrv, fp->buf, sect, 1) != RES_OK) {
-					EFSPRINTF("Error: Read - Low level disk I/O!\n(fill sector cache)");
+					EFSPRINTF("Read - Low level disk I/O!\n(fill sector cache)");
 					ABORT(fs, FR_DISK_ERR);	/* Fill sector cache */
 				}
 			}
@@ -3945,11 +3951,11 @@ FRESULT f_write (
 	*bw = 0;	/* Clear write byte counter */
 	res = validate(&fp->obj, &fs);			/* Check validity of the file object */
 	if (res != FR_OK || (res = (FRESULT)fp->err) != FR_OK) {
-		EFSPRINTF("Error: File object Validation!");
+		EFSPRINTF("File object Validation!");
 		LEAVE_FF(fs, res);	/* Check validity */
 	}
 	if (!(fp->flag & FA_WRITE)) {
-		EFSPRINTF("Error: Access denied!");
+		EFSPRINTF("Access denied!");
 		LEAVE_FF(fs, FR_DENIED);	/* Check access mode */
 	}
 
@@ -3979,15 +3985,15 @@ FRESULT f_write (
 					}
 				}
 				if (clst == 0) {
-					EFSPRINTF("Error: Could not allocate a new cluster\n(disk full or low level disk I/O error)!");
+					EFSPRINTF("Could not allocate a new cluster\n(disk full or low level disk I/O error)!");
 					break;		/* Could not allocate a new cluster (disk full) */
 				}
 				if (clst == 1) {
-					EFSPRINTF("Error: Cluster status check or Internal error!");
+					EFSPRINTF("Cluster status check or Internal error!");
 					ABORT(fs, FR_INT_ERR);
 				}
 				if (clst == 0xFFFFFFFF) {
-					EFSPRINTF("Error: Disk error (cluster hard error)!");
+					EFSPRINTF("Disk error (cluster hard error)!");
 					ABORT(fs, FR_DISK_ERR);
 				}
 				fp->clust = clst;			/* Update current cluster */
@@ -3998,7 +4004,7 @@ FRESULT f_write (
 #else
 			if (fp->flag & FA_DIRTY) {		/* Write-back sector cache */
 				if (disk_write(fs->pdrv, fp->buf, fp->sect, 1) != RES_OK) {
-					EFSPRINTF("Error: Write-back sector cache!");
+					EFSPRINTF("Write-back sector cache!");
 					ABORT(fs, FR_DISK_ERR);
 				}
 				fp->flag &= (BYTE)~FA_DIRTY;
@@ -4006,7 +4012,7 @@ FRESULT f_write (
 #endif
 			sect = clst2sect(fs, fp->clust);	/* Get current sector */
 			if (sect == 0) {
-				EFSPRINTF("Error: Get current sector error!");
+				EFSPRINTF("Get current sector error!");
 				ABORT(fs, FR_INT_ERR);
 			}
 			sect += csect;
@@ -4016,7 +4022,7 @@ FRESULT f_write (
 					cc = fs->csize - csect;
 				}
 				if (disk_write(fs->pdrv, wbuff, sect, cc) != RES_OK) {
-					EFSPRINTF("Error: Write - Low level disk I/O!");
+					EFSPRINTF("Write - Low level disk I/O!");
 					ABORT(fs, FR_DISK_ERR);
 				}
 #if FF_FS_MINIMIZE <= 2
@@ -4044,7 +4050,7 @@ FRESULT f_write (
 			if (fp->sect != sect && 		/* Fill sector cache with file data */
 				fp->fptr < fp->obj.objsize &&
 				disk_read(fs->pdrv, fp->buf, sect, 1) != RES_OK) {
-					EFSPRINTF("Error: Read - Low level disk I/O!\n(Could not fill sector cache with file data)");
+					EFSPRINTF("Read - Low level disk I/O!\n(Could not fill sector cache with file data)");
 					ABORT(fs, FR_DISK_ERR);
 			}
 #endif

--- a/ipl/gfx.c
+++ b/ipl/gfx.c
@@ -265,7 +265,7 @@ void gfx_hexdump(gfx_con_t *con, u32 base, const u8 *buf, u32 len)
 				for(u32 j = 0; j < 0x10; j++)
 				{
 					u8 c = buf[i - 0x10 + j];
-					if(c >= 32 && c < 128)
+					if(c >= 32 && c <= 126)
 						gfx_putc(con, c);
 					else
 						gfx_putc(con, '.');
@@ -275,6 +275,27 @@ void gfx_hexdump(gfx_con_t *con, u32 base, const u8 *buf, u32 len)
 			gfx_printf(con, "%08x: ", base + i);
 		}
 		gfx_printf(con, "%02x ", buf[i]);
+		if (i == len - 1)
+		{
+			int ln = len % 0x10 != 0;
+			u32 k = 0x10 - 1;
+			if (ln)
+			{
+				k = len & 0xF - 1;
+				for (u32 j = 0; j < 0x10 - k; j++)
+					gfx_puts(con, "   ");
+			}
+			gfx_puts(con, "| ");
+			for(u32 j = 0; j < (ln ? k : k + 1); j++)
+			{
+				u8 c = buf[i - k + j];
+				if(c >= 32 && c <= 126)
+					gfx_putc(con, c);
+				else
+					gfx_putc(con, '.');
+			}
+			gfx_putc(con, '\n');
+		}
 	}
 	gfx_putc(con, '\n');
 }

--- a/ipl/hos.c
+++ b/ipl/hos.c
@@ -378,8 +378,13 @@ int hos_launch(ini_sec_t *cfg)
 	memset(&ctxt, 0, sizeof(launch_ctxt_t));
 	list_init(&ctxt.kip1_list);
 
+	gfx_clear(&gfx_ctxt, 0xFF1B1B1B);
+	gfx_con_setpos(&gfx_con, 0, 0);
+
 	if (cfg && !_config(&ctxt, cfg))
 		return 0;
+        
+	gfx_printf(&gfx_con, "Initializing...\n\n");
 
 	//Read package1 and the correct keyblob.
 	if (!_read_emmc_pkg1(&ctxt))
@@ -497,7 +502,7 @@ int hos_launch(ini_sec_t *cfg)
 			break;
 	}
 
-	//Clear 'BootConfig'.
+	//Clear 'BootConfig' for retail systems.
 	memset((void *)0x4003D000, 0, 0x3000);
 
 	//pkg2_decrypt((void *)0xA9800000);

--- a/ipl/hos.c
+++ b/ipl/hos.c
@@ -386,7 +386,7 @@ int hos_launch(ini_sec_t *cfg)
 	gfx_printf(&gfx_con, "Loaded package1 and keyblob\n");
 	//Generate keys.
 	keygen(ctxt.keyblob, ctxt.pkg1_id->kb, (u8 *)ctxt.pkg1 + ctxt.pkg1_id->tsec_off);
-	DPRINTF("generated keys\n");
+	DPRINTF("Generated keys\n");
 	//Decrypt and unpack package1 if we require parts of it.
 	if (!ctxt.warmboot || !ctxt.secmon)
 	{

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -995,7 +995,7 @@ int dump_emmc_part(char *sd_path, sdmmc_storage_t *storage, emmc_part_t *part)
 	if(isSmallSdCard)
 	{
 		f_unlink(partialIdxFilename);
-		gfx_printf(&gfx_con, "%k%K\n\nYou can now join the files and get the complete raw eMMC dump.", 0xFFCCCCCC, 0xFF1B1B1B);
+		gfx_printf(&gfx_con, "%k\n\nYou can now join the files\nand get the complete raw eMMC dump.", 0xFFCCCCCC);
 	}
 	gfx_puts(&gfx_con, "\n\n");
 
@@ -1097,10 +1097,10 @@ static void dump_emmc_selected(dumpType_t dumpType)
 	}
 
 	gfx_putc(&gfx_con, '\n');
-	gfx_printf(&gfx_con, "%kTime taken: %d seconds.%k\n", 0xFF00FF96, (get_tmr() - timer) / 1000000, 0xFFCCCCCC);
+	gfx_printf(&gfx_con, "Time taken: %d seconds.\n", (get_tmr() - timer) / 1000000);
 	sdmmc_storage_end(&storage);
 	if (res)
-		gfx_puts(&gfx_con, "\nFinished and verified!\nPress any key.\n");
+		gfx_printf(&gfx_con, "\n%kFinished and verified!%k\nPress any key.\n",0xFF00FF96, 0xFFCCCCCC);
 
 out:;
 	btn_wait();

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -680,7 +680,6 @@ int dump_emmc_verify(sdmmc_storage_t *storage, u32 lba_curr, char* outFilename, 
 
 			if(!sdmmc_storage_read(storage, lbaCurrVer, num, bufEm))
 			{
-				gfx_con_setfontsz(&gfx_con, 16);
 				EPRINTFARGS("\nFailed to read %d blocks @ LBA %08X\nfrom eMMC. Aborting..\n",
 				num, lbaCurrVer);
 
@@ -691,7 +690,6 @@ int dump_emmc_verify(sdmmc_storage_t *storage, u32 lba_curr, char* outFilename, 
 			}
 			if (!(f_read(&fp, bufSd, num, NULL) == FR_OK))
 			{
-				gfx_con_setfontsz(&gfx_con, 16);
 				EPRINTFARGS("\nFailed to read %d blocks from sd card.\nVerification failed..\n", num);
 
 				free(bufEm);
@@ -702,7 +700,6 @@ int dump_emmc_verify(sdmmc_storage_t *storage, u32 lba_curr, char* outFilename, 
 
 			if(!memcmp(bufEm, bufSd, num << 9))
 			{
-				gfx_con_setfontsz(&gfx_con, 16);
 				EPRINTFARGS("\nVerification failed.\nVerification failed..\n", num);
 
 				free(bufEm);
@@ -732,7 +729,6 @@ int dump_emmc_verify(sdmmc_storage_t *storage, u32 lba_curr, char* outFilename, 
 	else
 	{
 		EPRINTF("\nFile not found or could not be loaded.\nVerification failed..\n");
-		gfx_con_setfontsz(&gfx_con, 16);
 		return 1;
 	}
 }

--- a/ipl/main.c
+++ b/ipl/main.c
@@ -516,7 +516,7 @@ void print_mmc_info()
 				boot_size / 1024, boot_size / 1024 / 512);
 			gfx_printf(&gfx_con, " 3: %kRPMB       %kSize: %5d KiB (LBA Sectors: 0x%07X)\n", 0xFF00FF96, 0xFFCCCCCC,
 				rpmb_size / 1024, rpmb_size / 1024 / 512);
-			gfx_printf(&gfx_con, " 0: %kGPP (USER) %kSize: %05d MiB (LBA Sectors: 0x%07X)\n\n", 0xFF00FF96, 0xFFCCCCCC,
+			gfx_printf(&gfx_con, " 0: %kGPP (USER) %kSize: %5d MiB (LBA Sectors: 0x%07X)\n\n", 0xFF00FF96, 0xFFCCCCCC,
 				storage.sec_cnt >> SECTORS_TO_MIB_COEFF, storage.sec_cnt);
 			gfx_printf(&gfx_con, "%kGPP (eMMC USER) partition table:%k\n", 0xFFFFDD00, 0xFFCCCCCC);
 
@@ -1287,12 +1287,12 @@ out:;
 void about()
 {
 	static const char octopus[] =
-	"hekate (c) 2018 naehrwert, st4rk\n\n"
+	"hekate (C) 2018 naehrwert, st4rk\n\n"
 	"Thanks to: %kderrek, nedwill, plutoo, shuffle2, smea, thexyz, yellows8%k\n\n"
 	"Greetings to: fincs, hexkyz, SciresM, Shiny Quagsire, WinterMute\n\n"
 	"Open source and free packages used:\n"
-	" - FatFs R0.13a (Copyright (C) 2017, ChaN)\n"
-	" - bcl-1.2.0 (Copyright (c) 2003-2006 Marcus Geelnard)\n\n"
+	" - FatFs R0.13a, (Copyright (C) 2017, ChaN)\n"
+	" - bcl-1.2.0,    (Copyright (C) 2003-2006, Marcus Geelnard)\n\n"
 	"                         %k___\n"
 	"                      .-'   `'.\n"
 	"                     /         \\\n"

--- a/ipl/pkg1.c
+++ b/ipl/pkg1.c
@@ -24,9 +24,12 @@
 #define _BL(a, o) 0x94000000 | (((o) - (a)) >> 2) & 0x3FFFFFF
 #define _NOP() 0xD503201F
 
+//#define SM_100_ADR 0x40014020
+#define SM_100_ADR 0x4002B020
+
 PATCHSET_DEF(_secmon_1_patchset,
-	//Patch the relocator to be able to run from 0x4002D000.
-	//{ 0x1E0, _ADRP(0, 0x7C013000 - 0x4002D000) }
+	//Patch the relocator to be able to run from SM_100_ADR.
+	{ 0x1E0, _ADRP(0, 0x7C013000 - (SM_100_ADR - 0x40)) },
 	//Patch package2 decryption and signature/hash checks.
 	{ 0x9F0 + 0xADC, _NOP() }, //Header signature.
 	{ 0x9F0 + 0xB8C, _NOP() }, //Version.
@@ -103,7 +106,7 @@ PATCHSET_DEF(_kernel_5_patchset,
 */
 
 static const pkg1_id_t _pkg1_ids[] = {
-	{ "20161121183008", 0, 0x1900, 0x3FE0, { 2, 1, 0 }, 0x40014020, _secmon_1_patchset, _kernel_1_patchset }, //1.0.0
+	{ "20161121183008", 0, 0x1900, 0x3FE0, { 2, 1, 0 }, SM_100_ADR, _secmon_1_patchset, _kernel_1_patchset }, //1.0.0 (Patched relocator)
 	{ "20170210155124", 0, 0x1900, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_2_patchset, _kernel_2_patchset }, //2.0.0 - 2.3.0
 	{ "20170519101410", 1, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.0
 	{ "20170710161758", 2, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.1 - 3.0.2

--- a/ipl/pkg1.c
+++ b/ipl/pkg1.c
@@ -48,21 +48,47 @@ PATCHSET_DEF(_secmon_3_patchset,
 	{ 0xAC8 + 0xADC, _NOP() }  //Sections SHA2.
 );
 
-PATCHSET_DEF(_secmon_5_patchset,
+PATCHSET_DEF(_secmon_4_patchset,
 	//Patch package2 decryption and signature/hash checks.
 	{ 0x1218 + 0x6E68, _NOP() }, //Header signature.
 	{ 0x1218 + 0x6E74, _NOP() }, //Version.
 	{ 0x1218 + 0x6FE4, _NOP() }, //Sections SHA2.
-	{ 0x1218 + 0x2DC, _NOP() }   //Unknown.
+	{ 0x1218 + 0x2DC,  _NOP() }  //Unknown.
 );
 
-PATCHSET_DEF(_secmon_6_patchset,
+PATCHSET_DEF(_secmon_5_patchset,
 	//Patch package2 decryption and signature/hash checks.
 	{ 0x12b0 + 0x4d0, _NOP() },
 	{ 0x12b0 + 0x4dc, _NOP() },
 	{ 0x12b0 + 0x794, _NOP() },
 	{ 0x12b0 + 0xb30, _NOP() }//,
 	//{ 0x12b0 + 0xa18 , _NOP() } // BootConfig Retail Check
+);
+
+// Include kernel patches here, so we can utilize pkg1 id
+PATCHSET_DEF(_kernel_1_patchset,
+	{ 0x3764C, _NOP() },         // Disable SVC verifications
+	{ 0x44074, _MOVZX(8, 1, 0) } // Enable Debug Patch
+);
+
+PATCHSET_DEF(_kernel_2_patchset,
+	{ 0x54834, _NOP() },         // Disable SVC verifications
+	{ 0x6086C, _MOVZX(8, 1, 0) } // Enable Debug Patch
+);
+
+PATCHSET_DEF(_kernel_3_patchset,
+	{ 0x3BD24, _NOP() },         // Disable SVC verifications
+	{ 0x483FC, _MOVZX(8, 1, 0) } // Enable Debug Patch
+);
+
+PATCHSET_DEF(_kernel_4_patchset,
+	{ 0x41EB4, _NOP() },         // Disable SVC verifications
+	{ 0x4EBFC, _MOVZX(8, 1, 0) } // Enable Debug Patch
+);
+
+PATCHSET_DEF(_kernel_5_patchset,
+	{ 0xFFFFFFFF, 0xFFFFFFFF },  // TODO: MISSING
+	{ 0x5513C, _MOVZX(8, 1, 0) } // Enable Debug Patch
 );
 
 /*
@@ -77,12 +103,12 @@ PATCHSET_DEF(_secmon_6_patchset,
 */
 
 static const pkg1_id_t _pkg1_ids[] = {
-	{ "20161121183008", 0, 0x1900, 0x3FE0, { 2, 1, 0 }, 0x40014020, _secmon_1_patchset }, //1.0.0
-	{ "20170210155124", 0, 0x1900, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_2_patchset }, //2.0.0
-	{ "20170519101410", 1, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset }, //3.0.0
-	{ "20170710161758", 2, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset }, //3.0.1
-	{ "20170921172629", 3, 0x1800, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_5_patchset }, //4.0.0
-	{ "20180220163747", 4, 0x1900, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_6_patchset }, //5.0.0
+	{ "20161121183008", 0, 0x1900, 0x3FE0, { 2, 1, 0 }, 0x40014020, _secmon_1_patchset, _kernel_1_patchset }, //1.0.0
+	{ "20170210155124", 0, 0x1900, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_2_patchset, _kernel_2_patchset }, //2.0.0 - 2.3.0
+	{ "20170519101410", 1, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.0
+	{ "20170710161758", 2, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.1 - 3.0.2
+	{ "20170921172629", 3, 0x1800, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_4_patchset, _kernel_4_patchset }, //4.0.0 - 4.1.0
+	{ "20180220163747", 4, 0x1900, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_5_patchset, _kernel_5_patchset }, //5.0.0 - 5.0.2
 	{ NULL, 0, 0, 0, 0 } //End.
 };
 

--- a/ipl/pkg1.c
+++ b/ipl/pkg1.c
@@ -90,7 +90,7 @@ PATCHSET_DEF(_kernel_4_patchset,
 );
 
 PATCHSET_DEF(_kernel_5_patchset,
-	{ 0xFFFFFFFF, 0xFFFFFFFF },  // TODO: MISSING
+	{ 0x45E6C, _NOP() },         // Disable SVC verifications
 	{ 0x5513C, _MOVZX(8, 1, 0) } // Enable Debug Patch
 );
 

--- a/ipl/pkg1.h
+++ b/ipl/pkg1.h
@@ -40,6 +40,7 @@ typedef struct _pkg1_id_t
 	u32 sec_map[3];
 	u32 secmon_base;
 	patch_t *secmon_patchset;
+	patch_t *kernel_patchset;
 } pkg1_id_t;
 
 typedef struct _pk11_hdr_t

--- a/ipl/sd.h
+++ b/ipl/sd.h
@@ -86,6 +86,7 @@
 #define UHS_SDR50_BUS_SPEED		2
 #define UHS_SDR104_BUS_SPEED	3
 #define UHS_DDR50_BUS_SPEED		4
+#define HS400_BUS_SPEED 		5
 
 /*
 * SD_SWITCH mode
@@ -102,6 +103,6 @@
 * SD_SWITCH access modes
 */
 #define SD_SWITCH_ACCESS_DEF	0
-#define SD_SWITCH_ACCESS_HS	1
+#define SD_SWITCH_ACCESS_HS		1
 
 #endif /* LINUX_MMC_SD_H */

--- a/ipl/sdmmc_driver.h
+++ b/ipl/sdmmc_driver.h
@@ -45,9 +45,28 @@
 #define SDMMC_RSP_TYPE_5 5
 
 /*! SDMMC mask interrupt status. */
-#define SDMMC_MASKINT_MASKED 0
+#define SDMMC_MASKINT_MASKED   0
 #define SDMMC_MASKINT_NOERROR -1
-#define SDMMC_MASKINT_ERROR -2
+#define SDMMC_MASKINT_ERROR   -2
+
+/*! SDMMC host control 2 */
+#define SDHCI_CTRL_UHS_MASK			0xFFF8
+#define SDHCI_CTRL_VDD_330			0xFFF7
+#define SDHCI_CTRL_VDD_180			8
+#define SDHCI_CTRL_EXEC_TUNING		0x40
+#define SDHCI_CTRL_TUNED_CLK		0x80
+#define SDHCI_HOST_VERSION_4_EN		0x1000
+#define SDHCI_ADDRESSING_64BIT_EN	0x2000
+#define SDHCI_CTRL_PRESET_VAL_EN	0x8000
+
+/*! SD bus speeds. */
+#define UHS_SDR12_BUS_SPEED		0
+#define HIGH_SPEED_BUS_SPEED	1
+#define UHS_SDR25_BUS_SPEED		1
+#define UHS_SDR50_BUS_SPEED		2
+#define UHS_SDR104_BUS_SPEED	3
+#define UHS_DDR50_BUS_SPEED		4
+#define HS400_BUS_SPEED 		5
 
 /*! Helper for SWITCH command argument. */
 #define SDMMC_SWITCH(mode, index, value) (((mode) << 24) | ((index) << 16) | ((value) << 8))

--- a/ipl/sdram_param_t210_lp0.h
+++ b/ipl/sdram_param_t210_lp0.h
@@ -262,7 +262,7 @@ struct sdram_params {
 	/* Specifies the value for EMC_PUTERM_WIDTH */
 	u32 EmcPutermWidth;
 	/* Specifies the value for EMC_PUTERM_ADJ */
-	u32 EmcPutermAdj;
+	////u32 EmcPutermAdj;
 
 	/* Specifies the value for EMC_QRST */
 	u32 EmcQRst;
@@ -647,7 +647,7 @@ struct sdram_params {
 	u32 EmcAcpdControl;
 
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE_CFG */
-	u32 EmcSwizzleRank0ByteCfg;
+	////u32 EmcSwizzleRank0ByteCfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE0 */
 	u32 EmcSwizzleRank0Byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE1 */
@@ -657,7 +657,7 @@ struct sdram_params {
 	/* Specifies the value for EMC_SWIZZLE_RANK0_BYTE3 */
 	u32 EmcSwizzleRank0Byte3;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE_CFG */
-	u32 EmcSwizzleRank1ByteCfg;
+	////u32 EmcSwizzleRank1ByteCfg;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE0 */
 	u32 EmcSwizzleRank1Byte0;
 	/* Specifies the value for EMC_SWIZZLE_RANK1_BYTE1 */

--- a/ipl/tui.c
+++ b/ipl/tui.c
@@ -25,7 +25,7 @@ void tui_pbar(gfx_con_t *con, int x, int y, u32 val, u32 fgcol, u32 bgcol)
 
 	gfx_con_setpos(con, x, y);
 
-	gfx_printf(con, "%k[%3d%%]%k", fgcol, val, bgcol);
+	gfx_printf(con, "%k[%3d%%]%k", fgcol, val, 0xFFCCCCCC);
 
 	x += 7 * 8;
 	

--- a/ipl/tui.c
+++ b/ipl/tui.c
@@ -17,7 +17,7 @@
 #include "tui.h"
 #include "btn.h"
 
-void tui_pbar(gfx_con_t *con, int x, int y, u32 val)
+void tui_pbar(gfx_con_t *con, int x, int y, u32 val, u32 fgcol, u32 bgcol)
 {
 	u32 cx, cy;
 
@@ -25,14 +25,14 @@ void tui_pbar(gfx_con_t *con, int x, int y, u32 val)
 
 	gfx_con_setpos(con, x, y);
 
-	gfx_printf(con, "[%3d%%]", val);
+	gfx_printf(con, "%k[%3d%%]%k", fgcol, val, bgcol);
 
 	x += 7 * 8;
 	
 	for (int i = 0; i < 6; i++)
 	{
-		gfx_line(con->gfx_ctxt, x, y + i + 1, x + 3 * val, y + i + 1, 0xFFCCCCCC);
-		gfx_line(con->gfx_ctxt, x + 3 * val, y + i + 1, x + 3 * 100, y + i + 1, 0xFF555555);
+		gfx_line(con->gfx_ctxt, x, y + i + 1, x + 3 * val, y + i + 1, fgcol);
+		gfx_line(con->gfx_ctxt, x + 3 * val, y + i + 1, x + 3 * 100, y + i + 1, bgcol);
 	}
 
 	gfx_con_setpos(con, cx, cy);

--- a/ipl/tui.h
+++ b/ipl/tui.h
@@ -57,7 +57,7 @@ typedef struct _menu_t
 #define MDEF_CAPTION(caption, color) { MENT_CAPTION, caption, color }
 #define MDEF_CHGLINE() {MENT_CHGLINE}
 
-void tui_pbar(gfx_con_t *con, int x, int y, u32 val);
+void tui_pbar(gfx_con_t *con, int x, int y, u32 val, u32 fgcol, u32 bgcol);
 void *tui_do_menu(gfx_con_t *con, menu_t *menu);
 
 #endif


### PR DESCRIPTION
**[PKG1] Move 1.0.0 secmon to 0x4002B020**
So, it's time to move **1.0.0 secmon**.
If we want to continue having a full featured bootloader, this change is a must.

It will move the secmon to **0x4002B000 + 0x20** (to keep the values addresses aligned).
Additionally, it fixes the relocator patch producing wrong instructions.

So now the payload size limit, to have all fw support, is **160KB - .bss**. (~155 to 158KB)
Additionally, switch back to performance -O2. We don't care anymore

**[PKG1] Add kernel patching**
Add Disable Svc Verification and Enable Debug mode.
Can be enabled via the hekate .ini, using the keys: **fullsvcperm=1**, **debugmode=1** .

Offsets/values from gist and comments in:
https://gist.github.com/roblabla/440f3ceaa0b2d3ca530c2a43fe258420

**[LP0] Inform user that console halted**
Actually this corrects sdram cfg parsing in LP0.
The cfg is missing 3 variables, which ultimately are unused in T210.
Remove them from the LP0 struct and fix configuration saving.

The console sleep, still does not work. But now it tries to enter/leave sleep and halts with backlight on.
At least, this reminds the user to power off the console to not deplete the battery completely.

**[Backup] Add dump verification**
At last a verification on the data read vs data written to ease the mind of the weary.

**[GFX] Fix hedump print last 1-16 bytes**
This fixes hexdump, which didn't print the ASCII of the last 1-16 chars. Also limits the characters into the printables ones.

**Bug fixes, wording, etc**