### PR TITLE
[DONTMERGE] Add 3.0.2 kernel patchset

### DIFF
--- a/ipl/pkg1.c
+++ b/ipl/pkg1.c
@@ -84,6 +84,11 @@ PATCHSET_DEF(_kernel_3_patchset,
 	{ 0x483FC, _MOVZX(8, 1, 0) } // Enable Debug Patch
 );
 
+PATCHSET_DEF(_kernel_302_patchset,
+	{ 0x3BD24, _NOP() },         // Disable SVC verifications
+	{ 0x48414, _MOVZX(8, 1, 0) } // Enable Debug Patch
+);
+
 PATCHSET_DEF(_kernel_4_patchset,
 	{ 0x41EB4, _NOP() },         // Disable SVC verifications
 	{ 0x4EBFC, _MOVZX(8, 1, 0) } // Enable Debug Patch
@@ -108,8 +113,8 @@ PATCHSET_DEF(_kernel_5_patchset,
 static const pkg1_id_t _pkg1_ids[] = {
 	{ "20161121183008", 0, 0x1900, 0x3FE0, { 2, 1, 0 }, SM_100_ADR, _secmon_1_patchset, _kernel_1_patchset }, //1.0.0 (Patched relocator)
 	{ "20170210155124", 0, 0x1900, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_2_patchset, _kernel_2_patchset }, //2.0.0 - 2.3.0
-	{ "20170519101410", 1, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.0
-	{ "20170710161758", 2, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.1 - 3.0.2
+	{ "20170519101410", 1, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_3_patchset }, //3.0.0 - 3.0.1
+	{ "20170710161758", 2, 0x1A00, 0x3FE0, { 0, 1, 2 }, 0x4002D000, _secmon_3_patchset, _kernel_302_patchset }, // 3.0.2
 	{ "20170921172629", 3, 0x1800, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_4_patchset, _kernel_4_patchset }, //4.0.0 - 4.1.0
 	{ "20180220163747", 4, 0x1900, 0x3FE0, { 1, 2, 0 }, 0x4002B000, _secmon_5_patchset, _kernel_5_patchset }, //5.0.0 - 5.0.2
 	{ NULL, 0, 0, 0, 0 } //End.


### PR DESCRIPTION
It turns out kernel 3.0.2 is different from kernel 3.0.0-3.0.1. As such, the DebugMode patch needs a slight tweak. Problem is, identification is done based on package1 build date right now, but 3.0.1 and 3.0.2 share the same package1, and AFAIK package2 doesn't have an easy way to identify the version used... Anyone know a good way to identify the package2?

ping @CTCaer 